### PR TITLE
Rebase to lastest master

### DIFF
--- a/industrial_ci/src/tests/clang_format_check.sh
+++ b/industrial_ci/src/tests/clang_format_check.sh
@@ -35,7 +35,7 @@ function run_clang_format_check() {
     ici_apt_install lsb-release software-properties-common gnupg
     ici_cmd wget -qO /tmp/llvm.sh https://apt.llvm.org/llvm.sh
     ici_cmd chmod +x /tmp/llvm.sh
-    ici_cmd /tmp/llvm.sh "$CLANG_FORMAT_VERSION"
+    ici_cmd ici_asroot /tmp/llvm.sh "$CLANG_FORMAT_VERSION"
   fi
 
   ici_apt_install git-core "$clang_format_executable"

--- a/industrial_ci/src/tests/clang_format_check.sh
+++ b/industrial_ci/src/tests/clang_format_check.sh
@@ -28,6 +28,16 @@ function run_clang_format_check() {
   local clang_format_executable="clang-format${CLANG_FORMAT_VERSION:+-$CLANG_FORMAT_VERSION}"
 
   ici_time_start install_clang_format
+
+  # Install llvm repository to install the correct clang version if not supported by default on the distro
+  if ! apt-cache search --names-only "$clang_format_executable" | grep -q "clang"; then
+    ici_install_pkgs_for_command wget wget
+    ici_apt_install lsb-release software-properties-common gnupg
+    ici_cmd wget -qO /tmp/llvm.sh https://apt.llvm.org/llvm.sh
+    ici_cmd chmod +x /tmp/llvm.sh
+    ici_cmd /tmp/llvm.sh "$CLANG_FORMAT_VERSION"
+  fi
+
   ici_apt_install git-core "$clang_format_executable"
   ici_time_end # install_clang_format
 

--- a/industrial_ci/src/workspace.sh
+++ b/industrial_ci/src/workspace.sh
@@ -373,7 +373,7 @@ function ici_install_dependencies {
       rosdep_opts+=(--skip-keys "$skip_keys")
     fi
 
-    ROS_PACKAGE_PATH="$cmake_prefix_path${ROS_PACKAGE_PATH:-}" ici_cmd ici_quiet ici_filter "(executing command)|(Setting up)" ici_exec_in_workspace "$extend" "." rosdep install "${rosdep_opts[@]}"
+    ROS_PACKAGE_PATH="$cmake_prefix_path${ROS_PACKAGE_PATH:-}" ici_cmd ici_quiet ici_filter "(executing command)|(Setting up)" ici_exec_in_workspace "$extend" "$@" rosdep install "${rosdep_opts[@]}"
 }
 
 function ici_build_workspace {


### PR DESCRIPTION
Description of the MR:
After the ROS keys expired on Jun 1st, 2025 updates were made to original Industrial ci repo that was needed to be pulled to enable testing ros images in CI pipelines.

## Changes

- Master branch of the fork was synced.
- Rebased the rosdep_fix_and_recent_clang_versions to the master branch.